### PR TITLE
Add link to Hero Icons website

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
     </a>
 </p>
 
-<p style="text-align: justify">The beautiful handcrafted Icons by the makers of Tailwind CSS
+<p style="text-align: justify">The [beautiful handcrafted Icons](https://www.heroicons.com) by the makers of Tailwind CSS
 made available to your awesome Avalonia UI projects!
 </p>
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,8 @@
     </a>
 </p>
 
-<p style="text-align: justify">The [beautiful handcrafted Icons](https://www.heroicons.com) by the makers of Tailwind CSS
+The [beautiful handcrafted Icons](https://www.heroicons.com) by the makers of Tailwind CSS
 made available to your awesome Avalonia UI projects!
-</p>
 
 <h4 align="center">HeroIcons.Avalonia Demo App</h4>
 


### PR DESCRIPTION
There's no link to the actual icons anywhere, which seems a little odd. This loses the justify for that first line (because the Markdown link wouldn't work inside a `<p>`), but the line is fairly short anyway, and it was the only line in the document that even had it.